### PR TITLE
Debug unknown backend_base_url variable

### DIFF
--- a/kpi_dashboard/frontend/nginx.conf
+++ b/kpi_dashboard/frontend/nginx.conf
@@ -11,12 +11,8 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # 런타임 환경변수 주입 엔드포인트
-    # 컨테이너 기동 시 설정된 BACKEND_BASE_URL 등을 프론트에서 window.__RUNTIME_CONFIG__로 읽도록 제공합니다
-    location = /runtime-config.js {
-        default_type application/javascript;
-        return 200 "window.__RUNTIME_CONFIG__ = { BACKEND_BASE_URL: '$BACKEND_BASE_URL' };";
-    }
+    # runtime-config.js는 엔트리포인트에서 정적으로 생성되어 루트에서 직접 서빙됩니다
+    # 별도 변수 치환 없이 정적 파일로 제공하므로 Nginx 변수 사용 오류를 방지합니다
 
     # 헬스체크
     location = /healthz {


### PR DESCRIPTION
Remove Nginx variable usage for `runtime-config.js` to resolve "unknown variable" errors.

The previous Nginx configuration attempted to use `$BACKEND_BASE_URL` directly in a `return` statement, leading to an "unknown variable" error during startup. This change ensures `runtime-config.js` is served as a static file, generated by the `docker-entrypoint.sh` script, thus bypassing Nginx's variable interpolation and resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-54bd9047-de1f-499d-87c5-7ca68c4eb463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54bd9047-de1f-499d-87c5-7ca68c4eb463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

