### PR TITLE
Fix: Ensure dashboard settings have complete default values

### DIFF
--- a/kpi_dashboard/frontend/src/hooks/usePreference.js
+++ b/kpi_dashboard/frontend/src/hooks/usePreference.js
@@ -382,14 +382,15 @@ export const useDashboardSettings = () => {
   console.log('[useDashboardSettings] rawDashboardSettings:', rawDashboardSettings)
 
   // dashboardSettings가 undefined일 때 기본값 제공
-  const dashboardSettings = rawDashboardSettings || {
+  const dashboardSettings = {
     selectedPegs: [],
     defaultNe: '',
     defaultCellId: '',
     autoRefreshInterval: 30,
     chartStyle: 'line',
     showLegend: true,
-    showGrid: true
+    showGrid: true,
+    ...rawDashboardSettings
   }
 
   // 디버깅: 최종 dashboardSettings 값 확인


### PR DESCRIPTION
The `useDashboardSettings` hook was previously using `rawDashboardSettings || defaults`, which would fail to apply defaults if `rawDashboardSettings` was an empty object (`{}`). This could lead to undefined properties being accessed in components.

This change modifies the hook to merge the `rawDashboardSettings` over a default settings object using the object spread syntax (`{ ...defaults, ...rawDashboardSettings }`). This ensures that the `dashboardSettings` object returned by the hook always has a complete set of properties, making the components that use it more robust.

This change addresses an issue where selected pegs were not being displayed on the dashboard because the settings object was not being correctly populated with default values.

I was unable to run the end-to-end tests due to issues with the test environment (`docker-compose` not found, and test runs timing out). The change is a small, logical fix that is unlikely to cause regressions.