### PR TITLE
Fix: Prevent infinite loop in optimized Dashboard

### DIFF
--- a/kpi_dashboard/frontend/src/components/Dashboard.optimized.jsx
+++ b/kpi_dashboard/frontend/src/components/Dashboard.optimized.jsx
@@ -207,15 +207,12 @@ const Dashboard = () => {
   
   // 현재 설정에서 값 추출 (기본값 포함) - 메모이제이션
   const settings = useMemo(() => {
-    // selectedPegs가 없거나 빈 배열이면 기본값 사용
-    const selectedPegs = dashboardSettings?.selectedPegs && dashboardSettings.selectedPegs.length > 0 
-      ? dashboardSettings.selectedPegs 
-      : defaultKpiKeys
+    // selectedPegs가 없거나 빈 배열이면 기본값 사용 -> 이제는 dashboardSettings의 값을 그대로 사용
+    const selectedPegs = dashboardSettings?.selectedPegs || []
     
     console.log('[Dashboard.optimized] settings 생성:', {
       dashboardSelectedPegs: dashboardSettings?.selectedPegs,
       finalSelectedPegs: selectedPegs,
-      defaultKpiKeys
     })
     
     return {
@@ -227,7 +224,7 @@ const Dashboard = () => {
       showLegend: dashboardSettings?.showLegend !== false,
       showGrid: dashboardSettings?.showGrid !== false
     }
-  }, [dashboardSettings, defaultKpiKeys])
+  }, [dashboardSettings])
 
   // 제목 매핑을 메모이제이션
   const titleMap = useMemo(() => ({

--- a/kpi_dashboard/frontend/src/hooks/usePreference.js
+++ b/kpi_dashboard/frontend/src/hooks/usePreference.js
@@ -382,14 +382,15 @@ export const useDashboardSettings = () => {
   console.log('[useDashboardSettings] rawDashboardSettings:', rawDashboardSettings)
 
   // dashboardSettings가 undefined일 때 기본값 제공
-  const dashboardSettings = rawDashboardSettings || {
+  const dashboardSettings = {
     selectedPegs: [],
     defaultNe: '',
     defaultCellId: '',
     autoRefreshInterval: 30,
     chartStyle: 'line',
     showLegend: true,
-    showGrid: true
+    showGrid: true,
+    ...rawDashboardSettings
   }
 
   // 디버깅: 최종 dashboardSettings 값 확인


### PR DESCRIPTION
The optimized Dashboard component was causing an infinite loop of data fetching. This was because it was ignoring the `selectedPegs` from the user's settings when the array was empty, and falling back to a hardcoded list of default pegs.

This change modifies the component to always respect the `selectedPegs` from the settings, even if the array is empty. This prevents the component from getting into a state where it continuously re-calculates its settings and triggers data fetches.

The logic in the `useMemo` hook that determines the `selectedPegs` has been corrected to use the value from `dashboardSettings` directly.