### PR TITLE
Refactor: Move test endpoints to a dedicated router

### DIFF
--- a/kpi_dashboard/backend/app/main.py
+++ b/kpi_dashboard/backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi.responses import JSONResponse
 
 # 내부 모듈 임포트
 from .db import connect_to_mongo, close_mongo_connection, get_db_stats
-from .routers import analysis, preference, kpi, statistics, master, llm_analysis, analysis_workflow, period_identification, statistical_comparison, anomaly_detection, integrated_analysis
+from .routers import analysis, preference, kpi, statistics, master, llm_analysis, analysis_workflow, period_identification, statistical_comparison, anomaly_detection, integrated_analysis, test
 from .routers.statistical_comparison import analysis_router
 from .middleware.performance import performance_middleware, setup_mongo_monitoring, get_performance_stats
 from .exceptions import (
@@ -218,30 +218,7 @@ app.include_router(statistical_comparison.router) # Statistical Comparison API
 app.include_router(analysis_router) # Analysis API
 app.include_router(anomaly_detection.router) # Anomaly Detection API
 app.include_router(integrated_analysis.router) # Integrated Analysis API
-
-# Add a test endpoint for Celery
-@app.post("/api/test-celery-task", summary="테스트 Celery 작업 실행", tags=["Test"])
-async def test_celery_task():
-    """
-    간단한 Celery 작업을 비동기적으로 실행하고 작업 ID를 반환합니다.
-    """
-    task = tasks.add_together.delay(2, 3)
-    return {"message": "Celery 작업이 시작되었습니다.", "task_id": task.id}
-
-# Add a simple test endpoint
-@app.post("/api/test-endpoint", summary="테스트 엔드포인트", tags=["Test"])
-async def test_endpoint():
-    """
-    간단한 테스트 엔드포인트
-    """
-    return {"message": "Test endpoint works!", "status": "success"}
-
-@app.get("/api/test-endpoint", summary="테스트 엔드포인트 GET", tags=["Test"])
-async def test_endpoint_get():
-    """
-    간단한 테스트 엔드포인트 (GET)
-    """
-    return {"message": "Test endpoint GET works!", "status": "success"}
+app.include_router(test.router)
 
 # 모니터링 라우터 추가
 from .routers import monitoring

--- a/kpi_dashboard/backend/app/routers/test.py
+++ b/kpi_dashboard/backend/app/routers/test.py
@@ -1,0 +1,29 @@
+"""
+Test-related API endpoints
+"""
+from fastapi import APIRouter
+from .. import tasks
+
+router = APIRouter()
+
+@router.post("/api/test-celery-task", summary="테스트 Celery 작업 실행", tags=["Test"])
+async def test_celery_task():
+    """
+    간단한 Celery 작업을 비동기적으로 실행하고 작업 ID를 반환합니다.
+    """
+    task = tasks.add_together.delay(2, 3)
+    return {"message": "Celery 작업이 시작되었습니다.", "task_id": task.id}
+
+@router.post("/api/test-endpoint", summary="테스트 엔드포인트", tags=["Test"])
+async def test_endpoint():
+    """
+    간단한 테스트 엔드포인트
+    """
+    return {"message": "Test endpoint works!", "status": "success"}
+
+@router.get("/api/test-endpoint", summary="테스트 엔드포인트 GET", tags=["Test"])
+async def test_endpoint_get():
+    """
+    간단한 테스트 엔드포인트 (GET)
+    """
+    return {"message": "Test endpoint GET works!", "status": "success"}


### PR DESCRIPTION
This commit resolves a `NameError` that occurred during application startup. The error was caused by having API endpoints defined directly in the main application file, which can lead to circular dependencies or initialization order issues.

The solution involves:
1. Creating a new router file `kpi_dashboard/backend/app/routers/test.py`.
2. Moving the test-related endpoints (`/api/test-celery-task`, `/api/test-endpoint`) from `kpi_dashboard/backend/app/main.py` to the new router file.
3. Updating `main.py` to import and include the new test router.

This change follows FastAPI best practices by separating concerns and ensures that the main application object is fully initialized before any routes are registered, thus preventing the `NameError`. The application now starts up correctly, as verified by running the test suite.